### PR TITLE
Implemented compatibility with LispWorks

### DIFF
--- a/ccl-compat.lisp
+++ b/ccl-compat.lisp
@@ -3,12 +3,8 @@
 ;;;; © Michał "phoe" Herda 2017
 ;;;; ccl-compat.lisp
 
-(in-package #:ccl)
+(in-package #:ccl-compat)
 
-;;;; Compatibility functions
-
-(defun neq (x y)
-  (not (eq x y)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;; DONE
@@ -533,11 +529,16 @@
 (defun key-arg-p (thing &optional lambda-ok)
   (pair-arg-p thing lambda-ok t t))
 
+
 (defun memq (item list)
+  #-:lispworks
   (do* ((tail list (cdr tail)))
        ((null tail))
     (if (eq item (car tail))
-      (return tail))))
+      (return tail)))
+  #+:lispworks
+  (system:memq item list))
+
 
 (defvar *nx-proclaimed-ignore* '())
 
@@ -553,9 +554,14 @@
    (if (verify-lambda-list thing t t)
      (setq *structured-lambda-list* t))))
 
+
 (defun assq (item list)
+  #-:lispworks
   (dolist (pair list)
-    (when (and pair (eq (car pair) item)) (return pair))))
+    (when (and pair (eq (car pair) item)) (return pair)))
+  #+:lispworks
+  (system:assq item list))
+
 
 ;;;; RECORD-ARGLIST
 
@@ -671,15 +677,11 @@ function and process in the warning message")
                  "it is not a proper list"
                  (let* ((len (length list)))
                    (if (eql min max)
-                     (format nil "it contains ~d elements, and exactly ~
-~d are expected" len min)
+                     (format nil "it contains ~d elements, and exactly ~d are expected" len min)
                      (if (< len min)
-                       (format nil "it contains ~d elements, and at ~
-least ~d are expected" len min)
-                       (format nil "it contains ~d elements, and at ~
-most ~d are expected" len max)))))
-               (format nil "it does not contain at least ~d ~
-elements" min))))
+                       (format nil "it contains ~d elements, and at least ~d are expected" len min)
+                       (format nil "it contains ~d elements, and at most ~d are expected" len max)))))
+               (format nil "it does not contain at least ~d elements" min))))
       (error
        "~s can't be destructured against the lambda list ~s, because ~a."
        list lambda-list reason))))

--- a/package.lisp
+++ b/package.lisp
@@ -3,8 +3,9 @@
 ;;;; © Michał "phoe" Herda 2017
 ;;;; package.lisp
 
-(defpackage #:ccl
+(defpackage #:ccl-compat
   (:use #:cl)
+  #-:lispworks (:nicknames #:ccl)
   (:export
    #:pkg-arg ;; function, DONE, edited
    #:no-such-package ;; condition, DONE, edited


### PR DESCRIPTION
- Now ccl-compat has its own package to avoid name clashes
  with compilers which have ccl buildin package (LispWorks)
- Fixed compatibility with LispWorks

Tested with LispWorks 6.1 Personal and 7.0 for Windows, CCL 1.11-r16635  (WindowsX8664), sbcl 1.3.15 Windows